### PR TITLE
Cleanup of params and services

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -90,7 +90,7 @@ node('large') {
             stage('Check') {
                 wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
                     sh """#!/bin/bash
-                    ./activator test
+                    ./activator clean test
                 """
                 }
             }

--- a/core-client/src/main/scala/de/welt/contentapi/core/client/models/ContentApi.scala
+++ b/core-client/src/main/scala/de/welt/contentapi/core/client/models/ContentApi.scala
@@ -15,7 +15,7 @@ case class ApiContentSearch(`type`: MainTypeParam = MainTypeParam(),
                             limit: LimitParam = LimitParam(),
                             page: PageParam = PageParam()
                            ) {
-  protected def allParams = Seq(`type`, subType, section, homeSection, sectionExcludes, flags, limit, page)
+  protected[models] def allParams = Seq(`type`, subType, section, homeSection, sectionExcludes, flags, limit, page)
 
   /**
     * Returns tuples of params ant their respective values {{{type -> news}}}.
@@ -50,7 +50,7 @@ sealed trait AbstractParam[T] {
   def asTuple: Option[(String, String)] = valueToStringOpt(value).map { v ⇒ (name, v) }
 }
 
-private abstract class ListParam[T](override val value: List[T]) extends AbstractParam[List[T]] {
+protected abstract class ListParam[T](override val value: List[T]) extends AbstractParam[List[T]] {
   // conjunction by default
   def operator: String = ","
 
@@ -64,7 +64,7 @@ private abstract class ListParam[T](override val value: List[T]) extends Abstrac
   }
 }
 
-private abstract class ValueParam[T](override val value: T) extends AbstractParam[T] with Loggable {
+protected abstract class ValueParam[T](override val value: T) extends AbstractParam[T] with Loggable {
   override def valueToStringOpt: T ⇒ Option[String] = PrimitiveParam[T]().valueToStringOpt
 }
 

--- a/core-client/src/main/scala/de/welt/contentapi/core/client/models/ContentApi.scala
+++ b/core-client/src/main/scala/de/welt/contentapi/core/client/models/ContentApi.scala
@@ -1,70 +1,107 @@
 package de.welt.contentapi.core.client.models
 
-case class ApiContentSearch(`type`: Option[MainTypeParam] = None,
-                            subType: Option[SubTypeParam] = None,
-                            section: Option[SectionParam] = None,
-                            homeSection: Option[HomeSectionParam] = None,
-                            sectionExcludes: Option[SectionExcludes] = None,
-                            flags: Option[FlagParam] = None,
-                            limit: Option[LimitParam] = None,
-                            page: Option[PageParam] = None
+import de.welt.contentapi.utils.Loggable
+
+case class ApiContentSearch(`type`: MainTypeParam = MainTypeParam(),
+                            subType: SubTypeParam = SubTypeParam(),
+                            section: SectionParam = SectionParam(),
+                            homeSection: HomeSectionParam = HomeSectionParam(),
+                            sectionExcludes: SectionExcludes = SectionExcludes(),
+                            flags: FlagParam = FlagParam(),
+                            limit: LimitParam = LimitParam(),
+                            page: PageParam = PageParam()
                            ) {
-  def allParams: Seq[Option[SearchParam]] = Seq(`type`, subType, section, homeSection, sectionExcludes, flags, limit, page)
+  def allParams = Seq(`type`, subType, section, homeSection, sectionExcludes, flags, limit, page)
 
-  def getAllParamsUnwrapped: Seq[(String, String)] = allParams
-    .filter(_.isDefined)
-    .map(_.get)
-    .map(_.getKeyValue)
+  def getAllParamsUnwrapped: Seq[(String, String)] = allParams.flatMap(_.asTuple)
 }
 
-sealed trait SearchParam {
-  val queryParamName: String
-  val queryValue: String
+sealed trait AbstractParam[T] {
 
-  def getKeyValue: (String, String) = (queryParamName, queryValue)
+  def name: String
+
+  def value: T
+
+  def valueToStringOpt: T ⇒ Option[String]
+
+  def asTuple: Option[(String, String)] = valueToStringOpt(value).map { v ⇒ (name, v) }
 }
 
+abstract class ListParam[T](override val value: List[T]) extends AbstractParam[List[T]] {
+  // conjunction by default
+  def operator: String = ","
 
-case class MainTypeParam(queryValue: String)
-  extends SearchParam {
-  override val queryParamName: String = "type"
+  override def valueToStringOpt: List[T] ⇒ Option[String] = {
+    case Nil ⇒ None
+    case nonEmpty ⇒ Some(nonEmpty.mkString(operator))
+  }
 }
 
-case class SubTypeParam(queryValue: String)
-  extends SearchParam {
-  override val queryParamName: String = "subType"
+abstract class ValueParam[T](override val value: T) extends AbstractParam[T] with Loggable {
+  override def valueToStringOpt: T ⇒ Option[String] = {
+    case s: String if s.nonEmpty ⇒ Some(s)
+    case _: String ⇒ None
+    case i: Int if i != Int.MinValue ⇒ Some(i.toString)
+    case _: Int ⇒ None
+    case unknown@_ ⇒
+      log.info(s"Unknown value type: ${unknown.getClass.toString}")
+      None
+  }
 }
 
-case class SectionParam(queryValue: String)
-  extends SearchParam {
-  override val queryParamName: String = "sectionPath"
+case class MainTypeParam(override val value: List[String] = Nil) extends ListParam[String](value) {
+  def this(singleValue: String) {
+    this(List(singleValue))
+  }
+  override val name: String = "type"
 }
 
-case class HomeSectionParam(queryValue: String)
-  extends SearchParam {
-  override val queryParamName: String = "sectionHome"
+case class SubTypeParam(override val value: List[String] = Nil) extends ListParam[String] (value){
+  def this(singleValue: String) {
+    this(List(singleValue))
+  }
+  override val name: String = "subType"
 }
 
-case class SectionExcludes(queryValue: String)
-  extends SearchParam {
-  override val queryParamName: String = "excludeSections"
+case class SectionParam(override val value: List[String] = Nil) extends ListParam[String](value) {
+  def this(singleValue: String) {
+    this(List(singleValue))
+  }
+  override val name: String = "sectionPath"
+
+  override def operator: String = "|" // disjunction by for sectionPath
 }
 
-case class FlagParam(queryValue: String)
-  extends SearchParam {
-  override val queryParamName: String = "flag"
+case class HomeSectionParam(override val value: List[String] = Nil) extends ListParam[String] (value){
+  def this(singleValue: String) {
+    this(List(singleValue))
+  }
+  override val name: String = "sectionHome"
+
+  override def operator: String = "|" // disjunction by for sectionPath
 }
 
-case class LimitParam(queryValue: String)
-  extends SearchParam {
-  override val queryParamName: String = "pageSize"
+case class SectionExcludes(override val value: List[String] = Nil) extends ListParam[String](value) {
+  def this(singleValue: String) {
+    this(List(singleValue))
+  }
+  override val name: String = "excludeSections"
 }
 
-case class PageParam(queryValue: String)
-  extends SearchParam {
-  override val queryParamName: String = "page"
+case class FlagParam(override val value: List[String] = Nil) extends ListParam[String] (value){
+  def this(singleValue: String) {
+    this(List(singleValue))
+  }
+  override val name: String = "flag"
 }
 
+case class LimitParam(override val value: Int = Int.MinValue) extends ValueParam[Int](value) {
+  override val name: String = "pageSize"
+}
+
+case class PageParam(override val value: Int = Int.MinValue) extends ValueParam[Int](value) {
+  override val name: String = "page"
+}
 
 sealed trait Datasource {
   val `type`: String
@@ -79,9 +116,7 @@ case class CuratedSource(override val maxSize: Option[Int],
 }
 
 case class SearchSource(override val maxSize: Option[Int],
-                        queries: Seq[SearchParam] = Seq()) extends Datasource {
+                        queries: Seq[AbstractParam[_]] = Seq()) extends Datasource {
   override val `type`: String = "search"
 }
-
-
 

--- a/core-client/src/main/scala/de/welt/contentapi/core/client/models/ContentApi.scala
+++ b/core-client/src/main/scala/de/welt/contentapi/core/client/models/ContentApi.scala
@@ -118,7 +118,7 @@ case class HomeSectionParam(override val value: List[String] = Nil) extends List
 
   override val name: String = "sectionHome"
 
-  override def operator: String = "|" // disjunction by for sectionPath
+  override def operator: String = "|" // disjunction by for sectionHome
 }
 
 case class SectionExcludes(override val value: List[String] = Nil) extends ListParam[String](value) {

--- a/core-client/src/main/scala/de/welt/contentapi/core/client/services/contentapi/ContentSearchService.scala
+++ b/core-client/src/main/scala/de/welt/contentapi/core/client/services/contentapi/ContentSearchService.scala
@@ -45,7 +45,7 @@ sealed trait ContentSearchService {
     * @param executionContext Play [[scala.concurrent.ExecutionContext]] for [[scala.concurrent.Future]]'s
     */
   def search(query: ApiContentSearch)
-            (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext): Future[Seq[ApiContent]]
+            (implicit requestHeaders: RequestHeaders = Seq.empty, executionContext: ExecutionContext): Future[Seq[ApiContent]]
 
 
   /**
@@ -72,7 +72,7 @@ class ContentSearchServiceImpl @Inject()(override val ws: WSClient,
   override val jsonValidate: (JsLookupResult) ⇒ JsResult[Seq[ApiContent]] = json ⇒ json.validate[Seq[ApiContent]]
 
   override def search(apiContentSearch: ApiContentSearch)
-                     (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext): Future[Seq[ApiContent]] = {
+                     (implicit requestHeaders: RequestHeaders  = Seq.empty, executionContext: ExecutionContext): Future[Seq[ApiContent]] = {
     super.get(urlArguments = Nil, parameters = apiContentSearch.getAllParamsUnwrapped)
   }
 

--- a/core-client/src/main/scala/de/welt/contentapi/core/client/services/contentapi/ContentService.scala
+++ b/core-client/src/main/scala/de/welt/contentapi/core/client/services/contentapi/ContentService.scala
@@ -43,7 +43,7 @@ trait ContentService {
     * @param executionContext Play [[scala.concurrent.ExecutionContext]] for [[scala.concurrent.Future]]'s
     */
   def find(id: String, showRelated: Boolean = true)
-          (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext): Future[ApiResponse]
+          (implicit requestHeaders: RequestHeaders = Seq.empty, executionContext: ExecutionContext): Future[ApiResponse]
 }
 
 @Singleton
@@ -59,7 +59,7 @@ class ContentServiceImpl @Inject()(override val ws: WSClient,
   override val jsonValidate: JsLookupResult ⇒ JsResult[ApiResponse] = _.validate[ApiResponse]
 
   override def find(id: String, showRelated: Boolean = true)
-                   (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext): Future[ApiResponse] = {
+                   (implicit requestHeaders: RequestHeaders = Seq.empty, executionContext: ExecutionContext): Future[ApiResponse] = {
 
     val parameters = if (showRelated) {
       Seq("show-related" → "true")

--- a/core-client/src/main/scala/de/welt/contentapi/core/client/utilities/Strings.scala
+++ b/core-client/src/main/scala/de/welt/contentapi/core/client/utilities/Strings.scala
@@ -1,0 +1,28 @@
+package de.welt.contentapi.core.client.utilities
+
+import com.google.common.base.CharMatcher
+
+trait Strings {
+
+  private val charMatcher = CharMatcher.WHITESPACE
+
+  /**
+    * remove all whitespaces from the string (such as {{{"\u00A0", " ", "\t", "\n"}}})
+    */
+  val stripWhiteSpaces = (s: String) ⇒ charMatcher.removeFrom(s)
+
+  /**
+    * `true` if `s` contains only whitespaces
+    * <br/> `false` otherwise
+    */
+  val containsOnlyWhitespaces = (s: String) ⇒ charMatcher.matchesAllOf(s)
+
+  /**
+    * `true` if `s` contains any non-whitespaces
+    * <br/> `false` otherwise
+    */
+  val containsTextContent = (s: String) ⇒ !containsOnlyWhitespaces(s)
+
+}
+
+object Strings extends Strings

--- a/core-client/src/test/scala/de/welt/contentapi/core/client/models/ApiContentSearchTest.scala
+++ b/core-client/src/test/scala/de/welt/contentapi/core/client/models/ApiContentSearchTest.scala
@@ -54,5 +54,14 @@ class ApiContentSearchTest extends PlaySpec {
       query.getAllParamsUnwrapped mustBe expectedListOfParams
     }
 
+    "main type is ','ed" in {
+      val mainTypeParam = ApiContentSearch(MainTypeParam(List("main1", "main2"))).getAllParamsUnwrapped
+      mainTypeParam must contain("type" → "main1,main2")
+    }
+
+    "home section is '|'ed" in {
+      val homeParam = ApiContentSearch(homeSection = HomeSectionParam(List("home1", "home2"))).getAllParamsUnwrapped
+      homeParam must contain("sectionHome" → "home1|home2")
+    }
   }
 }

--- a/core-client/src/test/scala/de/welt/contentapi/core/client/models/ApiContentSearchTest.scala
+++ b/core-client/src/test/scala/de/welt/contentapi/core/client/models/ApiContentSearchTest.scala
@@ -4,37 +4,36 @@ import org.scalatestplus.play.PlaySpec
 
 class ApiContentSearchTest extends PlaySpec {
 
-  val sectionPath: String = "/dickButt/"
-  val homeSectionPath: String = "/dickButt/"
-  val excludes: String = "-derpSection,-derpinaSection"
-  val maxResultSize: Int = 10
-  val page: Int = 1
-  val contentType: String = "live"
-  val subType: String = "ticker"
-  val flags: String = "highlight"
+  val sectionPath = "/dickButt/"
+  val homeSectionPath = "/dickButt/"
+  val excludes = List("-derpSection", "-derpinaSection")
+  val maxResultSize = 10
+  val page = 1
+  val contentType = "live"
+  val subType = "ticker"
+  val flags = "highlight"
 
   "ApiContentSearch" should {
 
-    "use all declared fields for creating the query paremeters" in {
-      val query: ApiContentSearch = ApiContentSearch(`type`= Some(MainTypeParam(contentType)))
-      val expectedListOfParams: Seq[(String, String)] = List(("type", "live"))
-
+    "use all declared fields for creating the query parameters" in {
+      val query: ApiContentSearch = ApiContentSearch(`type` = new MainTypeParam(contentType))
       query.allParams.size mustBe query.getClass.getDeclaredFields.length
     }
 
     "create a list of key value strings from all passed parameters which can be passed into the model" in {
       val query: ApiContentSearch = ApiContentSearch(
-        `type`= Some(MainTypeParam(contentType)),
-        subType = Some(SubTypeParam(subType)),
-        section = Some(SectionParam(sectionPath)),
-        homeSection = Some(HomeSectionParam(homeSectionPath)),
-        sectionExcludes = Some(SectionExcludes(excludes)),
-        flags = Some(FlagParam(flags)),
-        limit = Some(LimitParam(maxResultSize.toString)),
-        page = Some(PageParam(page.toString))
+        `type` = new MainTypeParam(contentType),
+        subType = new SubTypeParam(subType),
+        section = new SectionParam(sectionPath),
+        homeSection = new HomeSectionParam(homeSectionPath),
+        sectionExcludes = SectionExcludes(excludes),
+        flags = new FlagParam(flags),
+        limit = LimitParam(maxResultSize),
+        page = PageParam(page)
       )
 
-      val expectedListOfParams: Seq[(String, String)] = List(("type", "live"),
+      val expectedListOfParams: Seq[(String, String)] = List(
+        ("type", "live"),
         ("subType", "ticker"),
         ("sectionPath", "/dickButt/"),
         ("sectionHome", "/dickButt/"),
@@ -48,7 +47,7 @@ class ApiContentSearchTest extends PlaySpec {
 
     "create a list of key value strings only from defined parameters" in {
       val query: ApiContentSearch = ApiContentSearch(
-        `type`= Some(MainTypeParam(contentType))
+        `type` = new MainTypeParam(contentType)
       )
       val expectedListOfParams: Seq[(String, String)] = List(("type", "live"))
 

--- a/core-client/src/test/scala/de/welt/contentapi/core/client/services/contentapi/AbstractServiceTest.scala
+++ b/core-client/src/test/scala/de/welt/contentapi/core/client/services/contentapi/AbstractServiceTest.scala
@@ -69,32 +69,42 @@ class AbstractServiceTest extends PlaySpec
 
     "forward the X-Unique-Id header" in new TestScope {
       val headers = Seq(("X-Unique-Id", "0xdeadbeef"))
-      new TestService().get(Seq("fake-id"), Seq.empty)(Some(headers), defaultContext)
+      new TestService().get(Seq("fake-id"), Seq.empty)(headers, defaultContext)
       verify(mockRequest).withHeaders(("X-Unique-Id", "0xdeadbeef"))
     }
 
     "forward the auth data" in new TestScope {
       private val service = new TestService()
-      service.get(Seq("fake-id"), Seq("foo" -> "bar"))
+      service.get(Seq("fake-id"), Seq("foo" → "bar"))
       verify(mockRequest).withAuth(service.config.username, service.config.password, WSAuthScheme.BASIC)
     }
 
     "forward the query string data" in new TestScope {
-      new TestService().get(Seq("fake-id"), Seq("foo" -> "bar"))
+      new TestService().get(Seq("fake-id"), Seq("foo" → "bar"))
       verify(mockRequest).withQueryString(("foo", "bar"))
     }
 
     "forward the headers" in new TestScope {
-      implicit val requestHeaders: Option[RequestHeaders] = Some(Seq("X-Unique-Id" -> "bar"))
+      implicit val requestHeaders: RequestHeaders = Seq("X-Unique-Id" → "bar")
       new TestService().get(Seq("fake-id"), Seq.empty)
       verify(mockRequest).withHeaders(("X-Unique-Id", "bar"))
+    }
+
+    "strip whitespaces and newline from the parameter" in new TestScope {
+      new TestService().get(Seq("with-whitespace \n"))
+      verify(mockWsClient).url("http://www.example.com/test/with-whitespace")
+    }
+
+    "strip empty elements from the query string" in new TestScope {
+      new TestService().get(Seq("x"), Seq("spaces" → " \n", "trim" → "   value   "))
+      verify(mockRequest).withQueryString(("trim", "value"))
     }
 
     "will return the expected result" in new TestScope {
       when(responseMock.status).thenReturn(OK)
       when(responseMock.json).thenReturn(JsString("the result"))
 
-      val result: Future[String] = new TestService().get(Seq(""), Seq.empty)
+      val result: Future[String] = new TestService().get(Seq("x"), Seq.empty)
       val result1 = Await.result(result, 10.second)
       result1 mustBe "the result"
     }
@@ -136,7 +146,7 @@ class AbstractServiceTest extends PlaySpec
       when(responseMock.status).thenReturn(OK)
       when(responseMock.json).thenReturn(JsString(""))
 
-      val result: Future[String] = new TestService().get(Seq(""))
+      val result: Future[String] = new TestService().get(Seq("x"))
       Await.result(result, 10.second)
       verify(mockTimerContext).stop()
     }

--- a/legacy-client/src/main/scala/de/welt/contentapi/legacy/client/LegacySectionService.scala
+++ b/legacy-client/src/main/scala/de/welt/contentapi/legacy/client/LegacySectionService.scala
@@ -19,7 +19,7 @@ import play.api.libs.ws.WSClient
 import scala.concurrent.{ExecutionContext, Future}
 
 trait LegacySectionService {
-  def getByPath(path: String)(implicit requestHeaders: Option[RequestHeaders] = None,
+  def getByPath(path: String)(implicit requestHeaders: RequestHeaders = Seq.empty,
                               executionContext: ExecutionContext): Future[ApiLegacyPressedSection]
 }
 
@@ -38,7 +38,7 @@ class LegacySectionServiceImpl @Inject()(pressedContentService: PressedContentSe
   override val jsonValidate: (JsLookupResult) ⇒ JsResult[ApiLegacySection] = json => json.validate[ApiLegacySection]
 
   override def getByPath(path: String)
-                        (implicit requestHeaders: Option[RequestHeaders] = None,
+                        (implicit requestHeaders: RequestHeaders  = Seq.empty,
                          executionContext: ExecutionContext): Future[ApiLegacyPressedSection] = {
 
     val maybeRawChannel: Option[RawChannel] = findChannelForSection(path)

--- a/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/repository/PressedDiggerClient.scala
+++ b/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/repository/PressedDiggerClient.scala
@@ -22,7 +22,7 @@ sealed trait PressedDiggerClient {
     * @param env  Live/Preview, default = Live
     */
   def findByPath(path: String, env: Env = Live)
-                (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext): Future[ApiPressedSection]
+                (implicit requestHeaders: RequestHeaders = Seq.empty, executionContext: ExecutionContext): Future[ApiPressedSection]
 }
 
 case class PressedDiggerClientImpl @Inject()(override val ws: WSClient,
@@ -37,7 +37,7 @@ case class PressedDiggerClientImpl @Inject()(override val ws: WSClient,
     jsLookupResult.validate[ApiPressedSection](apiPressedSectionReads)
 
   override def findByPath(path: String, env: Env = Live)
-                         (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext): Future[ApiPressedSection] = {
+                         (implicit requestHeaders: RequestHeaders = Seq.empty, executionContext: ExecutionContext): Future[ApiPressedSection] = {
     get(urlArguments = Seq(env.toString, path), parameters = Nil)
   }
 

--- a/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/services/PressedContentService.scala
+++ b/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/services/PressedContentService.scala
@@ -26,7 +26,7 @@ trait PressedContentService {
     * @return a Future[ApiPressedContent]
     */
   def find(id: String, showRelated: Boolean = true)
-          (implicit requestHeaders: RequestHeaders, executionContext: ExecutionContext, env: Env = Live): Future[ApiPressedContent]
+          (implicit requestHeaders: RequestHeaders = Nil, executionContext: ExecutionContext, env: Env = Live): Future[ApiPressedContent]
 
   /**
     * Wraps ApiContent as ApiPressedContent with its Channel as ApiChannel and configuration data
@@ -54,7 +54,7 @@ class PressedContentServiceImpl @Inject()(contentService: ContentService,
   extends PressedContentService with Loggable {
 
   override def find(id: String, showRelated: Boolean = true)
-                   (implicit requestHeaders: RequestHeaders, executionContext: ExecutionContext, env: Env = Live): Future[ApiPressedContent] = {
+                   (implicit requestHeaders: RequestHeaders = Nil, executionContext: ExecutionContext, env: Env = Live): Future[ApiPressedContent] = {
     contentService
       .find(id, showRelated)
       .map(response ⇒ {

--- a/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/services/PressedContentService.scala
+++ b/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/services/PressedContentService.scala
@@ -26,7 +26,7 @@ trait PressedContentService {
     * @return a Future[ApiPressedContent]
     */
   def find(id: String, showRelated: Boolean = true)
-          (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext, env: Env = Live): Future[ApiPressedContent]
+          (implicit requestHeaders: RequestHeaders, executionContext: ExecutionContext, env: Env = Live): Future[ApiPressedContent]
 
   /**
     * Wraps ApiContent as ApiPressedContent with its Channel as ApiChannel and configuration data
@@ -54,7 +54,7 @@ class PressedContentServiceImpl @Inject()(contentService: ContentService,
   extends PressedContentService with Loggable {
 
   override def find(id: String, showRelated: Boolean = true)
-                   (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext, env: Env = Live): Future[ApiPressedContent] = {
+                   (implicit requestHeaders: RequestHeaders, executionContext: ExecutionContext, env: Env = Live): Future[ApiPressedContent] = {
     contentService
       .find(id, showRelated)
       .map(response ⇒ {

--- a/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/services/PressedSectionService.scala
+++ b/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/services/PressedSectionService.scala
@@ -24,7 +24,7 @@ case class PressedSectionServiceImpl @Inject()(pressedS3Client: PressedS3Client,
     * Primarily gets Pressed Section from S3, if pressed is older than 30 minutes or is not present -> fallback to digger rest call
     *
     * @param path path for section to be pressed
-    * @param env  can be Live or Preview, but is Live as default. If (Env == Preview) -> only ask Digger, dont try S3 first
+    * @param env  can be Live or Preview, but is Live as default. If (Env == Preview) -> only ask Digger, don't try S3 first
     * @return a future ApiPressedSection or deliver HttpClient/ServerError from AbstractService
     */
   override def findByPath(path: String, env: Env = Live)

--- a/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/services/PressedSectionService.scala
+++ b/pressed-client/src/main/scala/de/welt/contentapi/pressed/client/services/PressedSectionService.scala
@@ -15,7 +15,7 @@ trait PressedSectionService {
   val ttlInMinutes: Long = 30
 
   def findByPath(path: String, env: Env = Live)
-                (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext): Future[ApiPressedSection]
+                (implicit requestHeaders: RequestHeaders, executionContext: ExecutionContext): Future[ApiPressedSection]
 }
 
 case class PressedSectionServiceImpl @Inject()(pressedS3Client: PressedS3Client,
@@ -28,7 +28,7 @@ case class PressedSectionServiceImpl @Inject()(pressedS3Client: PressedS3Client,
     * @return a future ApiPressedSection or deliver HttpClient/ServerError from AbstractService
     */
   override def findByPath(path: String, env: Env = Live)
-                         (implicit requestHeaders: Option[RequestHeaders], executionContext: ExecutionContext): Future[ApiPressedSection] =
+                         (implicit requestHeaders: RequestHeaders, executionContext: ExecutionContext): Future[ApiPressedSection] =
 
   env match {
     case Preview ⇒ diggerClient.findByPath(path)

--- a/pressed-client/src/test/scala/de/welt/contentapi/pressed/client/services/PressedContentServiceTest.scala
+++ b/pressed-client/src/test/scala/de/welt/contentapi/pressed/client/services/PressedContentServiceTest.scala
@@ -84,12 +84,12 @@ class PressedContentServiceTest extends FlatSpec
   "PressedContentService" must "enrich an ApiResponse based on its home section" in new TestScope {
     // Given
     when(contentService
-      .find(id = "1234567890", showRelated = true)(None, executionContext))
+      .find(id = "1234567890", showRelated = true)(Seq.empty, executionContext))
       .thenReturn(eventualApiResponse)
     when(rawTreeService.root(any())).thenReturn(Some(root))
 
     // When
-    val eventualPressedContent: Future[ApiPressedContent] = pressedContentService.find("1234567890", showRelated = true)(None, executionContext)
+    val eventualPressedContent: Future[ApiPressedContent] = pressedContentService.find("1234567890", showRelated = true)(Seq.empty, executionContext)
     val apiPressedContent: ApiPressedContent = Await.result(eventualPressedContent, Timeout(30L, TimeUnit.SECONDS).duration)
 
     // Then

--- a/pressed-client/src/test/scala/de/welt/contentapi/pressed/client/services/PressedSectionServiceTest.scala
+++ b/pressed-client/src/test/scala/de/welt/contentapi/pressed/client/services/PressedSectionServiceTest.scala
@@ -23,7 +23,7 @@ class PressedSectionServiceTest extends FlatSpec
   with Matchers with MustVerb with MockitoSugar {
 
   implicit val ec = ExecutionContext.global
-  implicit val requestHeaders: Option[RequestHeaders] = None
+  implicit val requestHeaders: RequestHeaders = Seq.empty
 
   trait TestScope {
     val mockedS3Client: PressedS3Client = mock[PressedS3Client]

--- a/project/MyBuild.scala
+++ b/project/MyBuild.scala
@@ -13,7 +13,7 @@ object MyBuild extends Build {
   val forScala2_4 = Option(System.getenv("PLAY24")).exists(_.toBoolean)
 
   val playVersion = if (forScala2_4) "2.4.8" else "2.5.10"
-  private val actualVersion: String = s"0.7.$buildNumber"
+  private val actualVersion: String = s"0.8.$buildNumber"
 
   scalaVersion := "2.11.8"
 

--- a/project/MyBuild.scala
+++ b/project/MyBuild.scala
@@ -13,7 +13,7 @@ object MyBuild extends Build {
   val forScala2_4 = Option(System.getenv("PLAY24")).exists(_.toBoolean)
 
   val playVersion = if (forScala2_4) "2.4.8" else "2.5.10"
-  private val actualVersion: String = s"0.6.$buildNumber"
+  private val actualVersion: String = s"0.7.$buildNumber"
 
   scalaVersion := "2.11.8"
 

--- a/project/MyBuild.scala
+++ b/project/MyBuild.scala
@@ -13,7 +13,7 @@ object MyBuild extends Build {
   val forScala2_4 = Option(System.getenv("PLAY24")).exists(_.toBoolean)
 
   val playVersion = if (forScala2_4) "2.4.8" else "2.5.10"
-  private val actualVersion: String = s"0.8.$buildNumber"
+  private val actualVersion: String = s"0.7.$buildNumber"
 
   scalaVersion := "2.11.8"
 


### PR DESCRIPTION
-> updated minor from _0.7_ to _0.8_

**Breaking**

- type safe rewrite of the `ApiContentSearch`
- made the `RequestHeader` non `Optional`, but initialize with `Seq.empty` instead

**Updates**

- params for the `AbstractService` are getting trimmed now (remove leading and trailing white space) Fixes #42