### PR TITLE
Resilient Module Reads 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@ project/plugins/project/
 
 ### PlayFramework template
 # Ignore Play! working directory #
-bin/
 /db
 .eclipse
 /lib/

--- a/project/MyBuild.scala
+++ b/project/MyBuild.scala
@@ -13,7 +13,7 @@ object MyBuild extends Build {
   val forScala2_4 = Option(System.getenv("PLAY24")).exists(_.toBoolean)
 
   val playVersion = if (forScala2_4) "2.4.8" else "2.5.10"
-  private val actualVersion: String = s"0.10.$buildNumber"
+  private val actualVersion: String = s"0.11.$buildNumber"
 
   scalaVersion := "2.11.8"
 

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -363,6 +363,7 @@ object RawChannelStage {
   val customModule = "custom-module"
   val commercial = "commercial"
   val curated = "curated"
+  val unknown = "unknown"
 
   import de.welt.contentapi.raw.models.RawFormats.{rawChannelStageCommercialFormat, rawChannelStageContentFormat, rawChannelStageCuratedFormat}
 
@@ -434,7 +435,12 @@ case class RawChannelStageCurated(index: Int,
 
 }
 
-case class RawChannelStageIgnored(index: Int, hidden: Boolean = true) extends RawChannelStage {
-  override val `type`: String = "unknown"
+/**
+  * Unknown Modules will be parsed as [[RawChannelStageIgnored]] for future-proof Json Parsing
+  * Use Case: CMCF can be rolled out with new Modules that are not yet known to Digger
+  */
+case class RawChannelStageIgnored(index: Int) extends RawChannelStage {
+  override val `type`: String = RawChannelStage.unknown
+  override val hidden: Boolean = true
 }
 

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -434,3 +434,7 @@ case class RawChannelStageCurated(index: Int,
 
 }
 
+case class RawChannelStageIgnored(index: Int, hidden: Boolean = true) extends RawChannelStage {
+  override val `type`: String = "unknown"
+}
+

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
@@ -19,6 +19,7 @@ object RawFormats {
   implicit lazy val rawChannelCommercialFormat: Format[RawChannelCommercial] = Format[RawChannelCommercial](rawChannelCommercialReads, rawChannelCommercialWrites)
 
   implicit lazy val rawChannelStageContentFormat: Format[RawChannelStageCustomModule] = Format[RawChannelStageCustomModule](rawChannelStageContentReads, rawChannelStageCustomModuleWrites)
+  implicit lazy val rawChannelStageIgnoredFormat: Format[RawChannelStageIgnored] = Format[RawChannelStageIgnored](rawChannelStageIgnoredReads, rawChannelStageIgnoredWrites)
   implicit lazy val rawChannelStageCuratedFormat: Format[RawChannelStageCurated] = Format[RawChannelStageCurated](rawChannelStageCuratedReads, rawChannelStageCuratedWrites)
   implicit lazy val rawChannelStageCommercialFormat: Format[RawChannelStageCommercial] = Format[RawChannelStageCommercial](rawChannelStageCommercialReads, rawChannelStageCommercialWrites)
   implicit lazy val rawChannelStageFormat: Format[RawChannelStage] = Format[RawChannelStage](rawChannelStageReads, rawChannelStageWrites)
@@ -112,6 +113,7 @@ object RawReads {
   }
 
   implicit lazy val rawChannelStageContentReads: Reads[RawChannelStageCustomModule] = Json.reads[RawChannelStageCustomModule]
+  implicit lazy val rawChannelStageIgnoredReads: Reads[RawChannelStageIgnored] = Json.reads[RawChannelStageIgnored]
   implicit lazy val rawChannelStageCuratedReads: Reads[RawChannelStageCurated] = Json.reads[RawChannelStageCurated]
   implicit lazy val rawChannelStageCommercialReads: Reads[RawChannelStageCommercial] = Json.reads[RawChannelStageCommercial]
   implicit lazy val rawChannelStageReads = new Reads[RawChannelStage] {
@@ -125,6 +127,7 @@ object RawReads {
           Json.fromJson[RawChannelStageCommercial](json)
         case RawChannelStage.curated ⇒
           Json.fromJson[RawChannelStageCurated](json)
+        case _⇒ Json.fromJson[RawChannelStageIgnored](json)
       }
     }
   }
@@ -191,6 +194,7 @@ object RawWrites {
   implicit lazy val rawChannelCommercialWrites: Writes[RawChannelCommercial] = Json.writes[RawChannelCommercial]
 
   implicit lazy val rawChannelStageCustomModuleWrites: Writes[RawChannelStageCustomModule] = Json.writes[RawChannelStageCustomModule]
+  implicit lazy val rawChannelStageIgnoredWrites: Writes[RawChannelStageIgnored] = Json.writes[RawChannelStageIgnored]
   implicit lazy val rawChannelStageCuratedWrites: Writes[RawChannelStageCurated] = Json.writes[RawChannelStageCurated]
   implicit lazy val rawChannelStageCommercialWrites: Writes[RawChannelStageCommercial] = Json.writes[RawChannelStageCommercial]
   implicit lazy val rawChannelStageWrites = new Writes[RawChannelStage] {

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
@@ -127,7 +127,7 @@ object RawReads {
           Json.fromJson[RawChannelStageCommercial](json)
         case RawChannelStage.curated ⇒
           Json.fromJson[RawChannelStageCurated](json)
-        case _⇒ Json.fromJson[RawChannelStageIgnored](json)
+        case _ ⇒ Json.fromJson[RawChannelStageIgnored](json)
       }
     }
   }

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/RawReadsTest.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/RawReadsTest.scala
@@ -61,4 +61,25 @@ class RawReadsTest extends PlaySpec {
     }
 
   }
+
+  "RawChannelStage Reads" must {
+
+    "parse unknown modules as a hidden RawChannelStageIgnored" in {
+      val unknownModule = """{
+                            |  "index": 0,
+                            |  "hidden": false,
+                            |  "type": "my-fance-new-module",
+                            |  "layout": "fancy-layout"
+                            |}"""".stripMargin
+      val unknownStage = Json.parse(unknownModule)
+        .validate[RawChannelStage](rawChannelStageReads)
+        .asOpt
+        .get
+      unknownStage.`type` mustBe RawChannelStage.unknown
+      unknownStage.hidden mustBe true
+    }
+
+  }
+
+
 }


### PR DESCRIPTION
**Changes**
- added case class `RawChannelStageIgnored`

**Use Case**
- Future proof Json Parsing 
- Digger can ignore unknown *new* modules from CMCF
- CMCF can be rolled out with new Modules that are not yet known to Digger
- will be ignored