### PR TITLE
bugfix/optional-field-hideCuratedStageLabel

### DIFF
--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawChannel.scala
@@ -445,7 +445,7 @@ case class RawChannelStageCurated(override val index: Int,
                                   label: Option[String],
                                   logo: Option[String],
                                   references: Option[Seq[RawSectionReference]] = None,
-                                  hideCuratedStageLabel: Boolean = false) extends RawChannelStage {
+                                  hideCuratedStageLabel: Option[Boolean] = None) extends RawChannelStage {
   lazy val unwrappedReferences: Seq[RawSectionReference] = references.getOrElse(Nil)
 
 }

--- a/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
+++ b/raw/src/main/scala/de/welt/contentapi/raw/models/RawFormats.scala
@@ -289,7 +289,7 @@ object RawWrites {
       (__ \ "label").writeNullable[String] and
       (__ \ "logo").writeNullable[String] and
       (__ \ "references").writeNullable[Seq[RawSectionReference]] and
-      (__ \ "hideCuratedStageLabel").write[Boolean]
+      (__ \ "hideCuratedStageLabel").writeNullable[Boolean]
     ) (unlift(RawChannelStageCurated.unapply))
 
   implicit lazy val rawChannelStageTrackingWrites: Writes[RawChannelStageTracking] = (

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/RawReadsTest.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/RawReadsTest.scala
@@ -116,8 +116,7 @@ class RawReadsTest extends PlaySpec {
         |}
       """.stripMargin
 
-    """|ignore empty (`String.empty`) override values
-       |Prevent of parse empty number values""".stripMargin in {
+    "ignore empty override values to prevent parsing empty number values" in {
       val customStage: RawChannelStageCustomModule = Json.parse(customStageJson)
         .validate[RawChannelStageCustomModule](rawChannelStageCustomModuleReads)
         .asOpt
@@ -126,7 +125,25 @@ class RawReadsTest extends PlaySpec {
       customStage.unwrappedOverrides.get("limit") mustBe None
     }
 
+
   }
 
-
+  "RawChannelStageCurated Reads" must {
+    "work if defined values are missing in Json" in  {
+      // while writing this test a new field was added (hideCuratedStageLabel) and is missing in the following json
+      val json = """{
+        |  "index": 0,
+        |  "type": "curated",
+        |  "hidden": false,
+        |  "trackingName": "sondergruppe-1",
+        |  "curatedSectionMapping": "frontpage",
+        |  "curatedStageMapping": "sondergruppe-1",
+        |  "layout": "oembed",
+        |  "references": []
+        |}
+      """.stripMargin
+      val stage: Option[RawChannelStageCurated] = Json.parse(json).validateOpt[RawChannelStageCurated](rawChannelStageCuratedReads).get
+      stage.get.`type` mustBe RawChannelStage.TypeCurated
+    }
+  }
 }

--- a/raw/src/test/scala/de/welt/contentapi/raw/models/RawWritesTest.scala
+++ b/raw/src/test/scala/de/welt/contentapi/raw/models/RawWritesTest.scala
@@ -171,8 +171,7 @@ class RawWritesTest extends PlaySpec {
            |    "path" : "https://www.dick-butt.org"
            |  },
            |  "curatedSectionMapping" : "frontpage",
-           |  "curatedStageMapping" : "hero",
-           |  "hideCuratedStageLabel" : false
+           |  "curatedStageMapping" : "hero"
            |}""".stripMargin
     }
 
@@ -191,7 +190,7 @@ class RawWritesTest extends PlaySpec {
         references = Some(Seq(
           RawSectionReference(label = Some("ref-label"), path = Some("ref-path"))
         )),
-        hideCuratedStageLabel = true
+        hideCuratedStageLabel = Some(true)
       )
 
       val expectedJson: String =


### PR DESCRIPTION
make field hideCuratedStageLabel optional to be resilient in Json Reads