### PR TITLE
- add optional http headers

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3 (2018-03-20)
+
+- add optional http headers in AbstractService
+
 ## 1.2 bugfix (2018-03-16)
 
 - definition which Exceptions will cause the breaker to stay open or allow close. e.g.

--- a/core-client/src/main/scala/de/welt/contentapi/core/client/services/contentapi/AbstractService.scala
+++ b/core-client/src/main/scala/de/welt/contentapi/core/client/services/contentapi/AbstractService.scala
@@ -89,10 +89,13 @@ abstract class AbstractService[T](ws: WSClient,
   /**
     * @param urlArguments            string interpolation arguments for endpoint. e.g. /foo/%s/bar/%s see [[java.lang.String#format}]]
     * @param parameters              URL parameters to be sent with the request
+    * @param headers                 optional http headers to be sent to the backend
     * @param forwardedRequestHeaders forwarded request headers from the controller e.g. API key
     * @return
     */
-  def get(urlArguments: Seq[String] = Nil, parameters: Seq[(String, String)] = Nil)
+  def get(urlArguments: Seq[String] = Nil,
+          parameters: Seq[(String, String)] = Nil,
+          headers: Seq[(String, String)] = Nil)
          (implicit forwardedRequestHeaders: RequestHeaders = Seq.empty): Future[T] = {
 
     val context = initializeMetricsContext(config.serviceName)
@@ -103,6 +106,7 @@ abstract class AbstractService[T](ws: WSClient,
 
     val getRequest: WSRequest = ws.url(url)
       .withQueryStringParameters(filteredParameters: _*)
+      .addHttpHeaders(headers: _*)
       .addHttpHeaders(forwardHeaders(forwardedRequestHeaders): _*)
 
     val preparedRequest = config.credentials match {

--- a/core-client/src/test/scala/de/welt/contentapi/core/client/services/contentapi/AbstractServiceTest.scala
+++ b/core-client/src/test/scala/de/welt/contentapi/core/client/services/contentapi/AbstractServiceTest.scala
@@ -103,6 +103,12 @@ class AbstractServiceTest extends PlaySpec with MockitoSugar with Status with Te
       verify(mockRequest).withQueryStringParameters(("foo", "bar"))
     }
 
+
+    "will send headers to the backend" in new TestScopeBasicAuth {
+      new TestService().get(Seq("fake-id"), Seq.empty, headers = Seq("header-name" -> "header-value"))
+      verify(mockRequest).addHttpHeaders(("header-name", "header-value"))
+    }
+
     "forward the headers" in new TestScopeBasicAuth {
       implicit val requestHeaders: RequestHeaders = Seq("X-Unique-Id" -> "bar")
       new TestService().get(Seq("fake-id"), Seq.empty)


### PR DESCRIPTION
## What
- add optional http headers (part of BER-5333)

## Why
- needed for Qwant Search