### PR TITLE
Fixed parameter handling

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
         stage('Check') {
             when { expression { BRANCH_NAME ==~ /^PR-.*/ } }
             steps {
-                wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
+                ansiColor('xterm') {
                     sh "./sbt clean test"
                 }
             }
@@ -28,7 +28,7 @@ pipeline {
             parallel {
                 stage('Scala Style') {
                     steps {
-                        wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
+                        ansiColor('xterm') {
                             sh './sbt scalastyle'
                         }
                         step([$class: 'CheckStylePublisher', pattern: '**/scalastyle-result.xml'])
@@ -36,7 +36,7 @@ pipeline {
                 }
                 stage('Test') {
                     steps {
-                        wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
+                        ansiColor('xterm') {
                             sh './sbt clean coverage test'
                         }
                         junit '**/target/test-reports/*.xml'
@@ -48,7 +48,7 @@ pipeline {
         stage('Coverage') {
             when { allOf { branch 'master'; expression { return !params.QUICK_DEPLOY } } }
             steps {
-                wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
+                ansiColor('xterm') {
                     sh './sbt coverageReport'
                     sh './sbt coverageAggregate'
                 }
@@ -62,7 +62,7 @@ pipeline {
             environment { BINTRAY_USER = "ci-weltn24" }
             steps {
                 withCredentials([[$class: 'StringBinding', credentialsId: 'BINTRAY_API_KEY_CI_WELTN24', variable: 'BINTRAY_PASS']]) {
-                    wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
+                    ansiColor('xterm') {
                         sh './sbt publish'
                     }
                     slackSend channel: 'section-tool-2', message: "Successfully published a new WeltContentApiClient version: ${env.BUILD_URL}"
@@ -71,9 +71,6 @@ pipeline {
         }
     }
     post {
-        success {
-            slackSend color: "good", channel: 'section-tool-2', message: ":rocket: Successfully published a new WeltContentApiClient version: ${env.BUILD_URL}"
-        }
         failure {
             slackSend color: "danger", channel: 'section-tool-2', message: ":facepalm: Build failed: ${env.BUILD_URL}"
         }

--- a/core-client/src/main/scala/de/welt/contentapi/core/client/services/contentapi/AbstractService.scala
+++ b/core-client/src/main/scala/de/welt/contentapi/core/client/services/contentapi/AbstractService.scala
@@ -102,10 +102,10 @@ abstract class AbstractService[T](ws: WSClient,
 
     val url: String = config.host + config.endpoint.format(urlArguments.map(stripWhiteSpaces).filter(_.nonEmpty): _*)
 
-    val filteredParameters = parameters.map { case (k, v) ⇒ k → stripWhiteSpaces(v) }.filter(_._2.nonEmpty)
+    val nonEmptyParameters = parameters.map { case (k, v) ⇒ k -> v.trim }.filter(_._2.nonEmpty)
 
     val getRequest: WSRequest = ws.url(url)
-      .withQueryStringParameters(filteredParameters: _*)
+      .withQueryStringParameters(nonEmptyParameters: _*)
       .addHttpHeaders(headers: _*)
       .addHttpHeaders(forwardHeaders(forwardedRequestHeaders): _*)
 

--- a/core-client/src/test/scala/de/welt/contentapi/core/client/services/contentapi/AbstractServiceTest.scala
+++ b/core-client/src/test/scala/de/welt/contentapi/core/client/services/contentapi/AbstractServiceTest.scala
@@ -132,8 +132,25 @@ class AbstractServiceTest extends PlaySpec with MockitoSugar with Status with Te
     }
 
     "strip empty elements from the query string" in new TestScopeBasicAuth {
-      new TestService().get(Seq("x"), Seq("spaces" → " \n", "trim" → "   value   "))
-      verify(mockRequest).withQueryStringParameters(("trim", "value"))
+      new TestService().get(
+        urlArguments = Seq("x"),
+        parameters = Seq("spaces" → " \n"))
+      verify(mockRequest).withQueryStringParameters()
+    }
+
+    "trim whitespaces from parameters" in new TestScopeBasicAuth {
+      new TestService().get(
+        urlArguments = Seq("x"),
+        parameters = Seq("trim" → "   value   "))
+      verify(mockRequest).withQueryStringParameters("trim" → "value")
+    }
+
+    // proxy qwant onward search request
+    "allow whitespace in parameter value because request builder will escape it correctly" in new TestScopeBasicAuth {
+      new TestService().get(
+        urlArguments = Seq("x"),
+        parameters = Seq("query" → "Angela Merkel"))
+      verify(mockRequest).withQueryStringParameters("query" → "Angela Merkel")
     }
 
     "will return the expected result" in new TestScopeBasicAuth {
@@ -193,6 +210,7 @@ class AbstractServiceTest extends PlaySpec with MockitoSugar with Status with Te
 }
 
 object AbstractServiceTest extends MockitoSugar with TestExecutionContext {
+
   trait TestScope {
 
     val mockWsClient: WSClient = mock[WSClient]
@@ -213,4 +231,5 @@ object AbstractServiceTest extends MockitoSugar with TestExecutionContext {
     when(metricsMock.defaultRegistry).thenReturn(new com.codahale.metrics.MetricRegistry())
     when(mockWsClient.url(anyString)).thenReturn(mockRequest)
   }
+
 }


### PR DESCRIPTION
- allow whitespace to occur within query parameter values (e.g. to support qwant searches)