### PR TITLE
fixed assertions for search responses

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ def withTests(project: Project) = project % "test->test;compile->compile"
 
 val frontendCompilationSettings = Seq(
   organization := "de.welt",
-  scalaVersion := "2.12.5",
+  scalaVersion := "2.12.6",
   version in ThisBuild := s"${actualVersion}_$PlayVersion${if (isSnapshot) "-SNAPSHOT" else ""}",
 
   licenses += ("MIT", url("http://opensource.org/licenses/MIT")),

--- a/pressed/src/main/scala/de/welt/contentapi/pressed/models/ApiPressedResponse.scala
+++ b/pressed/src/main/scala/de/welt/contentapi/pressed/models/ApiPressedResponse.scala
@@ -60,8 +60,9 @@ case class ApiPressedContentResponse(result: ApiPressedContent,
   extends ApiPressedResponse(source, StatusPhrase.ok, StatusPhrase.HttpStatusOk) with ApiPaging {
 
   pageSize.foreach(i ⇒ require(i > 0, "pageSize must be greater than 0"))
-  pages.foreach(i ⇒ require(i > 0, "pages must be greater than 0 (starting at 1)"))
   currentPage.foreach(i ⇒ require(i > 0, "currentPage must be greater than 0 (starting at 1)"))
+  pages.foreach(i ⇒ require(i >= 0, "pages must be ≥ 0 (starting at 0)"))
+  total.foreach(i ⇒ require(i >= 0, "total must be ≥ 0 (starting at 0)"))
 }
 
 object StatusPhrase extends Enumeration {


### PR DESCRIPTION
- allow pages and total to be `== 0`
- bump scala to latest version

fixes WeltN24/up-cigger#8